### PR TITLE
Correct offline_store config to enable BigQuerySources

### DIFF
--- a/driver_ranking/feature_store.yaml
+++ b/driver_ranking/feature_store.yaml
@@ -1,3 +1,6 @@
 project: driver_ranking
 registry: data/registry.db
 provider: local
+offline_store:
+  type: bigquery
+  dataset: feast_bq_dataset


### PR DESCRIPTION
If not changed, then this error occurs:

```bash
$ poetry run python train.py
Traceback (most recent call last):
  File "~\feast-driver-ranking-tutorial\train.py", line 14, in <module>
    training_df = fs.get_historical_features(
  File "[...]\feast\infra\offline_stores\file.py", line 41, in to_df
    df = self.evaluation_function()
  File "[...]\feast\infra\offline_stores\file.py", line 115, in evaluate_historical_retrieval
    table = pyarrow.parquet.read_table(feature_view.batch_source.path)
AttributeError: 'BigQuerySource' object has no attribute 'path'
```

The error occurs because, when left undefined, `FeatureStore.config.offline_store` defaults to `FileOfflineStoreConfig(type='file')` - which is incorrect.

More specifically, in `train.py`:
```python
# Connect to your local feature store
fs = feast.FeatureStore(repo_path="driver_ranking/")

# Check FeatureStore.config
fs.config.offline_store # should return FileOfflineStoreConfig(type='file')
```